### PR TITLE
Fix table by removing extraneous column from  row

### DIFF
--- a/api-standards.md
+++ b/api-standards.md
@@ -1384,7 +1384,7 @@ The following status codes represent appropriate responses to the different oper
 
 
 | Request Method | Resource Path | Status | Code |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | 
 | GET | `/resources/` | OK | 200 |
 ||| Bad Request | 400 | 
 ||| Unauthorised | 401 | 


### PR DESCRIPTION
The markdown table wasn't rendering due to an extra column in the heading separator.