### PR TITLE
Mandating OpenAPI document, latest version preferred

### DIFF
--- a/api-standards.md
+++ b/api-standards.md
@@ -408,7 +408,7 @@ ______________________________________________________________________________
 <h1 id="3">3. WoVG API Requirements</h1>
 <h3 id="3-1">3.1 API Documentation</h3>
 
-Well documented APIs are a critical component of a successful API programme. All APIs created for the Victorian government **MUST** specify a valid OpenAPI v2 document. 
+Well documented APIs are a critical component of a successful API programme. All APIs created for the Victorian government **MUST** specify a valid OpenAPI document (latest stable version preferred). 
 
 This assists with the interoperability of services through a common descriptive document.  Where possible the structure, methods, naming conventions and responses will also be standardised to ensure a common experience for developers accessing services from a range of publishers.
 
@@ -2085,7 +2085,7 @@ ______________________________________________________________________________
 
 
 ## API STANDARDS REFERENCED
-> [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md)
+> [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/)
 > [White House Web API Standards](https://github.com/WhiteHouse/api-standards)
 > [18F API Standards](https://github.com/18F/api-standards)
 > [Gov.UK API Service Manual](https://www.gov.uk/service-manual/technology/application-programming-interfaces-apis)


### PR DESCRIPTION
First, I would like to say that this is a great initiative. Opening the standards for review on GitHub is fantastic, thank you! Without further ado, please find below my first pull request for this repo.

The latest version of the OpenAPI standard (v3.0.2) allows for [callbacks](https://swagger.io/docs/specification/callbacks/), improved examples and updated parameter types. We are assisting a VIC Government department with an API which implements webhooks (and WebSockets) for which the defining of callbacks is key.

This pull request removes the reference to the older OpenAPI version (2) and replaces it with a 'latest version preferred' statement. This pull request also updates the OpenAPI specifications link to point to the root directory, rather than v2.